### PR TITLE
Fixed wrong conf check for awseb

### DIFF
--- a/commands/rocket.go
+++ b/commands/rocket.go
@@ -123,7 +123,7 @@ var RocketCmd = &cobra.Command{
 		}
 
 		// aws_eb
-		if conf.ZeitNow != nil {
+		if conf.AWSEB != nil {
 			log.Debug("aws_eb: starting provider")
 			err = awseb.Deploy(*conf.AWSEB)
 			if err != nil {


### PR DESCRIPTION
I noticed that for the AWS EB conf check it was checking Zeit instead of AWSEB